### PR TITLE
Initialize int_sync and irq_flags in non DT use case.

### DIFF
--- a/gt9xx.c
+++ b/gt9xx.c
@@ -1967,6 +1967,9 @@ static int gtp_probe(struct i2c_client *client, const struct i2c_device_id *id)
 	pdata->abs_size_y = GTP_DEFAULT_MAX_Y;
 	pdata->max_touch_width = GTP_DEFAULT_MAX_WIDTH;
 	pdata->max_touch_pressure = GTP_DEFAULT_MAX_PRESSURE;
+	pdata->int_sync = true;
+	pdata->irq_flags = GTP_DEFAULT_INT_TRIGGER;
+
 #endif
 
 	ts->client = client;


### PR DESCRIPTION
Both fields need to be populated in the non device tree use case to make
the touch controller work.

When int_sync is not set to true,
the initialization sequence is never finished by the host cpu
and the controller remains in limbo.

If the irq_flags are unassigned, falling edge triggered is assumed but
the controller does rising edge triggered interrupts by default.